### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,20 @@ Configure in `mcp.json`:
 
 Reference in agents with `mcp:fetch`.
 
+### Built-in: Exa search
+
+The default `mcp.json` ships with an `exa` server pre-configured against Exa's
+hosted MCP endpoint. Set `EXA_API_KEY` (get one at
+[dashboard.exa.ai](https://dashboard.exa.ai/api-keys)) and the following tools
+become available to any agent that includes `mcp:exa`:
+
+- `web_search_exa` — neural web search with clean, ready-to-use content
+- `web_search_advanced_exa` — domain/date/text filters, highlights, summaries
+- `web_fetch_exa` — fetch full page content as markdown
+
+If `EXA_API_KEY` is unset the server simply fails to connect and is skipped —
+the rest of the MCP config is unaffected.
+
 ## Tool Types
 
 | Prefix | Description |

--- a/templates/.env.example
+++ b/templates/.env.example
@@ -1,0 +1,12 @@
+# Agent Orcha environment variables
+#
+# Copy this file to `.env` in your workspace and fill in the values
+# for any integrations you want to enable. All variables are optional —
+# Agent Orcha will run without any of them; the corresponding features
+# are disabled when their env var is unset.
+
+# Exa — AI-powered web search and content retrieval via MCP.
+# Create a key at https://dashboard.exa.ai/api-keys and the `exa`
+# server in `mcp.json` will connect on startup, exposing `web_search_exa`,
+# `web_search_advanced_exa`, and `web_fetch_exa` to your agents.
+EXA_API_KEY=

--- a/templates/mcp.json
+++ b/templates/mcp.json
@@ -3,6 +3,16 @@
   "servers": {
     "htmlhost": {
       "url": "https://htmlhost.jax.workers.dev/mcp"
+    },
+    "exa": {
+      "transport": "streamable-http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "${EXA_API_KEY:-}",
+        "x-exa-integration": "agent-orcha"
+      },
+      "description": "Exa AI-powered web search and content retrieval. Set EXA_API_KEY to enable.",
+      "enabled": true
     }
   },
   "globalOptions": {

--- a/test/templates/mcp-template.test.ts
+++ b/test/templates/mcp-template.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { MCPConfigSchema } from '../../lib/mcp/types.ts';
+import { substituteEnvVars } from '../../lib/utils/env-substitution.ts';
+
+const templatePath = path.resolve(import.meta.dirname, '../../templates/mcp.json');
+
+describe('templates/mcp.json', () => {
+  const saved = { EXA_API_KEY: process.env.EXA_API_KEY };
+
+  beforeEach(() => {
+    delete process.env.EXA_API_KEY;
+  });
+
+  afterEach(() => {
+    if (saved.EXA_API_KEY === undefined) delete process.env.EXA_API_KEY;
+    else process.env.EXA_API_KEY = saved.EXA_API_KEY;
+  });
+
+  it('parses against MCPConfigSchema', () => {
+    const raw = fs.readFileSync(templatePath, 'utf-8');
+    const parsed = JSON.parse(substituteEnvVars(raw));
+    const result = MCPConfigSchema.safeParse(parsed);
+    assert.ok(result.success, `Schema validation failed: ${result.success ? '' : JSON.stringify(result.error.issues)}`);
+  });
+
+  it('registers the exa server with the hosted MCP URL and tracking header', () => {
+    const raw = fs.readFileSync(templatePath, 'utf-8');
+    const parsed = JSON.parse(substituteEnvVars(raw));
+    const cfg = MCPConfigSchema.parse(parsed);
+    const exa = cfg.servers.exa;
+
+    assert.ok(exa, 'exa server should be present in the template');
+    assert.equal(exa.transport, 'streamable-http');
+    assert.equal(exa.url, 'https://mcp.exa.ai/mcp');
+    assert.equal(exa.headers?.['x-exa-integration'], 'agent-orcha');
+    assert.ok('x-api-key' in (exa.headers ?? {}), 'x-api-key header must be declared');
+  });
+
+  it('leaves x-api-key empty when EXA_API_KEY is unset (server still parses, connection will fail gracefully)', () => {
+    const raw = fs.readFileSync(templatePath, 'utf-8');
+    const parsed = JSON.parse(substituteEnvVars(raw));
+    const cfg = MCPConfigSchema.parse(parsed);
+    assert.equal(cfg.servers.exa?.headers?.['x-api-key'], '');
+  });
+
+  it('substitutes EXA_API_KEY into x-api-key when set', () => {
+    process.env.EXA_API_KEY = 'test-key-123';
+    const raw = fs.readFileSync(templatePath, 'utf-8');
+    const parsed = JSON.parse(substituteEnvVars(raw));
+    const cfg = MCPConfigSchema.parse(parsed);
+    assert.equal(cfg.servers.exa?.headers?.['x-api-key'], 'test-key-123');
+  });
+});


### PR DESCRIPTION
## Summary

- Registers `exa` in the default `templates/mcp.json`, pointing at Exa's hosted MCP endpoint (`https://mcp.exa.ai/mcp`) via the `streamable-http` transport.
- Exposes three search tools to any agent that lists `mcp:exa`:
  - `web_search_exa` — neural web search with clean, ready-to-use content
  - `web_search_advanced_exa` — domain/date/text filters, highlights, summaries
  - `web_fetch_exa` — fetch full page content as markdown
- Adds `templates/.env.example` (bootstrap already copies this file if present) documenting `EXA_API_KEY`, so users discover the key variable on first run.
- Updates the README's MCP Servers section with a short "Built-in: Exa search" subsection.
- Adds `test/templates/mcp-template.test.ts` validating the template parses against `MCPConfigSchema` and substitutes `${EXA_API_KEY}` correctly.

## Why MCP (not a new API client)

Exa ships a first-party hosted MCP server, so wiring it in via `mcp.json` reuses the existing `MCPClientManager`, transport, tool registration, `/api/mcp/*` routes, and Studio MCP browser — no new code paths, no new dependency. Agents opt in with `mcp:exa` exactly like any other MCP server.

## Usage

1. Get a key at [dashboard.exa.ai](https://dashboard.exa.ai/api-keys).
2. `export EXA_API_KEY=...` (or put it in the workspace `.env`).
3. Reference the tools in any agent:

```yaml
# ~/.orcha/workspace/agents/researcher.agent.yaml
name: researcher
llm: default
tools:
  - mcp:exa
```

When `EXA_API_KEY` is unset, the header substitutes to an empty string via the existing `${VAR:-}` pattern, the connection fails auth, and the existing graceful-failure path logs a warning — no crash, no impact on other servers.

## Files changed

- `templates/mcp.json` — add `exa` server entry with `x-api-key` (from `${EXA_API_KEY:-}`) and `x-exa-integration: agent-orcha` tracking header
- `templates/.env.example` — new file documenting `EXA_API_KEY`
- `README.md` — add "Built-in: Exa search" subsection under MCP Servers
- `test/templates/mcp-template.test.ts` — new test covering schema, header shape, and env-var substitution

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `node --experimental-test-module-mocks --test test/templates/mcp-template.test.ts` — 4/4 pass
- [x] `node --experimental-test-module-mocks --test test/mcp/mcp-client.test.ts` — unchanged, still green (24/24)
- [x] `node --experimental-test-module-mocks --test test/utils/env-substitution.test.ts` — still green (11/11)
- [x] `node --experimental-test-module-mocks --test test/orchestrator.test.ts` — still green (73/73), including `reloadFile for mcp.json`
- [ ] Manual smoke test against a real `EXA_API_KEY` (reviewer to verify end-to-end if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)